### PR TITLE
WIP: guiding text displays when chart/map views are blanked

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -42,6 +42,15 @@ export const App = props => {
   const tabLinks = props.widgets.map((widget, index) => {
     return <TabLink to={widget.name} className='mr-4' key={`tabLink-${index}`}>{widget.name}</TabLink>
   })
+
+  const viewGuidedMessage = (specType) => {
+    return (
+    <div> 
+      {specType === 'simple' ? <p>Select chart type, group column and series from the right side pane in order to build a chart.</p>: '' }  
+      {specType === 'tabularmap' ? <p>Select geo data from the right side panel inorder to build a chart.</p>: '' }  
+    </div>
+    )}
+
   const tabContents = props.widgets.map((widget, index) => {
     return <TabContent for={widget.name} key={`tabContent-${index}`}>
         {
@@ -53,12 +62,13 @@ export const App = props => {
             </div>
           : <div className="container flex py-6">
               <div className="w-3/4 py-3 mr-4">
-                <DataView {...widget} />
+              {!widget.datapackage.views[0].spec ? <div>{viewGuidedMessage(widget.datapackage.views[0].specType)}</div> : ''}
+              <DataView {...widget} />
               </div>
               <div className="w-1/4">
                 <div className="w-full">
                   <div className="p-4 mr-4">
-                    {
+                   {
                       widget.datapackage.views[0].specType === 'simple'
                       ? <ChartBuilder view={widget.datapackage.views[0]} dataViewBuilderAction={props.dataViewBuilderAction} />
                       : ''

--- a/src/App.js
+++ b/src/App.js
@@ -43,11 +43,11 @@ export const App = props => {
     return <TabLink to={widget.name} className='mr-4' key={`tabLink-${index}`}>{widget.name}</TabLink>
   })
 
-  const viewGuidedMessage = (specType) => {
+  const viewGuidingText = (specType) => {
     return (
-    <div> 
-      {specType === 'simple' ? <p>Select chart type, group column and series from the right side pane in order to build a chart.</p>: '' }  
-      {specType === 'tabularmap' ? <p>Select geo data from the right side panel inorder to build a chart.</p>: '' }  
+    <div className="dx-guiding-text"> 
+      {specType === 'simple' ? <p>Select chart type, group column (ordinate x-axis) and series (abscissa y-axis) on the right hand side panel.</p>: '' }  
+      {specType === 'tabularmap' ? <p>Select geo data field on the right hand side panel.</p>: '' }  
     </div>
     )}
 
@@ -62,7 +62,7 @@ export const App = props => {
             </div>
           : <div className="container flex py-6">
               <div className="w-3/4 py-3 mr-4">
-              {!widget.datapackage.views[0].spec ? <div>{viewGuidedMessage(widget.datapackage.views[0].specType)}</div> : ''}
+              {!widget.datapackage.views[0].spec ? <div>{viewGuidingText(widget.datapackage.views[0].specType)}</div> : ''}
               <DataView {...widget} />
               </div>
               <div className="w-1/4">

--- a/src/App.js
+++ b/src/App.js
@@ -46,8 +46,8 @@ export const App = props => {
   const viewGuidingText = (specType) => {
     return (
     <div className="dx-guiding-text"> 
-      {specType === 'simple' ? <p>Select chart type, group column (ordinate x-axis) and series (abscissa y-axis) on the right hand side panel.</p>: '' }  
-      {specType === 'tabularmap' ? <p>Select geo data field on the right hand side panel.</p>: '' }  
+      {specType === 'simple' ? <p>Select chart type, group column (ordinate x-axis) and series (abscissa y-axis) on the right hand side panel.</p> : '' }  
+      {specType === 'tabularmap' ? <p>Select geo data field on the right hand side panel.</p> : '' }  
     </div>
     )}
 


### PR DESCRIPTION
- Chart and map option will render some guiding text initially when views don't have specs.

<img width="1440" alt="Screen Shot 2020-03-12 at 5 33 15 PM" src="https://user-images.githubusercontent.com/11631101/76518669-a633da00-6487-11ea-98d3-0bf0cf073ec3.png">

<img width="1440" alt="Screen Shot 2020-03-12 at 5 33 21 PM" src="https://user-images.githubusercontent.com/11631101/76518673-a9c76100-6487-11ea-8b7d-34cb8ff2fec5.png">
