### PR TITLE
New translations en fr da tablinks

### DIFF
--- a/dist/App.js
+++ b/dist/App.js
@@ -31,6 +31,10 @@ var _actions = require("./actions/");
 
 var _utils = require("./utils");
 
+require("./i18n/i18n");
+
+var _reactI18next = require("react-i18next");
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
@@ -53,7 +57,11 @@ var App = function App(props) {
   }, []);
   var activeWidget = props.widgets.find(function (widget) {
     return widget.active;
-  }); // Check if any of widgets requires datastore specific components:
+  });
+
+  var _useTranslation = (0, _reactI18next.useTranslation)(),
+      t = _useTranslation.t; // Check if any of widgets requires datastore specific components:
+
 
   var nonDataStoreViewTypes = ['web', 'document'];
   var datastoreComponents = props.widgets.find(function (widget) {
@@ -68,7 +76,7 @@ var App = function App(props) {
       to: widget.name,
       className: "mr-4",
       key: "tabLink-".concat(index)
-    }, widget.name);
+    }, t(widget.name));
   });
   var tabContents = props.widgets.map(function (widget, index) {
     return _react.default.createElement(_reactTabsRedux.TabContent, {
@@ -102,7 +110,7 @@ var App = function App(props) {
     className: "total-rows"
   }, _react.default.createElement("span", {
     className: "total-rows-label"
-  }, "Total Rows"), ": ", _react.default.createElement("span", {
+  }, t('Total rows')), ": ", _react.default.createElement("span", {
     className: "total-rows-value"
   }, totalRows)), _react.default.createElement("div", {
     className: "datastore-query-builder"

--- a/dist/i18n/locales/da/translation.json
+++ b/dist/i18n/locales/da/translation.json
@@ -8,5 +8,6 @@
   "Previous": "Tidligere",
   "Table": "Bord",
   "Map": "Kort",
-  "Chart": "Diagram"
+  "Chart": "Diagram",
+  "Total rows": "Samlede rækker"
 }

--- a/dist/i18n/locales/en/translation.json
+++ b/dist/i18n/locales/en/translation.json
@@ -8,5 +8,6 @@
   "Previous": "Previous",
   "Table": "Table",
   "Map": "Map",
-  "Chart": "Chart"
+  "Chart": "Chart",
+  "Total rows": "Total rows"
 }

--- a/dist/i18n/locales/fr/translation.json
+++ b/dist/i18n/locales/fr/translation.json
@@ -8,5 +8,6 @@
   "Previous": "Précédent",
   "Table": "Tableau",
   "Map": "Carte",
-  "Chart": "Graphique"
+  "Chart": "Graphique",
+  "Total rows": "Entrées totales"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datopian/data-explorer",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "private": false,
   "main": "/dist/AppWithProvider.js",
   "module": "/dist/AppWithProvider.js",

--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,9 @@ import { Tabs, TabLink, TabContent } from 'react-tabs-redux'
 import { filterUIAction, fetchDataAction, dataViewBuilderAction, selectTabAction } from './actions/'
 import { getResourceForFiltering, showQueryBuilder } from './utils'
 
+import "./i18n/i18n";
+import { useTranslation } from "react-i18next";
+
 export const App = props => {
   useEffect(() => {
     const payload = {
@@ -23,6 +26,8 @@ export const App = props => {
   const activeWidget = props.widgets.find(widget => {
     return widget.active
   })
+
+  const { t } = useTranslation();
 
   // Check if any of widgets requires datastore specific components:
   const nonDataStoreViewTypes = ['web', 'document']
@@ -40,7 +45,7 @@ export const App = props => {
 
   const selectedTab = activeWidget ? activeWidget.name : props.widgets[0].name
   const tabLinks = props.widgets.map((widget, index) => {
-    return <TabLink to={widget.name} className='mr-4' key={`tabLink-${index}`}>{widget.name}</TabLink>
+    return <TabLink to={widget.name} className='mr-4' key={`tabLink-${index}`}>{t(widget.name)}</TabLink>
   })
 
 
@@ -81,7 +86,7 @@ export const App = props => {
   return (
     <div className="data-explorer">
       {totalRows && datastoreComponents && (<div className="total-rows">
-        <span className="total-rows-label">Total Rows</span>: <span className="total-rows-value">{totalRows}</span>
+        <span className="total-rows-label">{t('Total rows')}</span>: <span className="total-rows-value">{totalRows}</span>
       </div>)
       }
       {/* Data Editor (aka filters / datastore query builder) */}

--- a/src/i18n/locales/da/translation.json
+++ b/src/i18n/locales/da/translation.json
@@ -8,5 +8,6 @@
   "Previous": "Tidligere",
   "Table": "Bord",
   "Map": "Kort",
-  "Chart": "Diagram"
+  "Chart": "Diagram",
+  "Total rows": "Samlede rækker"
 }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -8,5 +8,6 @@
   "Previous": "Previous",
   "Table": "Table",
   "Map": "Map",
-  "Chart": "Chart"
+  "Chart": "Chart",
+  "Total rows": "Total rows"
 }

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -8,5 +8,6 @@
   "Previous": "Précédent",
   "Table": "Tableau",
   "Map": "Carte",
-  "Chart": "Graphique"
+  "Chart": "Graphique",
+  "Total rows": "Entrées totales"
 }


### PR DESCRIPTION
@anuveyatsu 
This update of `data-explorer` fixes `Tab link names` translation. Also this fixes translation of `Total rows` string.
I made all three translation files ('en', 'da' and 'fr') uniform - all of them have same strings.
This `build` is tested in Montreal theme (locally) and there is no issues.